### PR TITLE
Add support for macos-lastest build

### DIFF
--- a/lib/setup-chromedriver.sh
+++ b/lib/setup-chromedriver.sh
@@ -5,13 +5,19 @@ set -eo pipefail
 VERSION=$1
 ARCH=$2
 
-if ! type -a google-chrome > /dev/null 2>&1; then
-    sudo apt-get update
-    sudo apt-get install -y google-chrome
+if [ "$ARCH" == "linux64" ]; then
+    if ! type -a google-chrome > /dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y google-chrome
+    fi
 fi
 
 if [ "$VERSION" == "" ]; then
-  CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+    if [ "$ARCH" == "mac64" ]; then
+        CHROME_VERSION=$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+    elif [ "$ARCH" == "linux64" ]; then
+        CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+    fi
   VERSION=$(curl --location --fail --retry 10 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
 fi
 


### PR DESCRIPTION
I just discovered this action and thought it was amazing. Unfortunately, support for anything other than linux-based builds seems to have broken, possibly [due to a recent update](https://github.com/nanasess/setup-chromedriver/commit/06a97fc8dcf7bdaae35a5d401bec3b18bd350c35)

None of this is really my strong suit, I'm new to a lot of this stuff, but I was able to add `macos-latest` support back with some additional condition checks. There is likely a better way to go about this. Also tested under `ubuntu-latest`, but not tried under any Windows-based builds as I don't have access to Windows for troubleshooting.

If logging an issue would make more sense, please reject and let me know, just happy to contribute in any way.

Also, as I'm still shaky on shell scripts, I ran `lib/install-chromedriver.sh` through `shellcheck` and it threw some warnings about `Double quote to prevent globbing and word splitting` on lines like `rm chromedriver_${ARCH}.zip`, but it's not causing any issues, so leaving for another day/PR.

Thanks for all the work that went into this action!