### PR TITLE
Add input description to avoid warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: 'setup-chromedriver'
 description: 'Setup chromedriver'
 author: 'nanasess'
+inputs:
+  chromedriver-version:
+    description: 'The chromedriver version to install'
+    required: false
 runs:
   using: 'node12'
   main: 'lib/setup-chromedriver.js'


### PR DESCRIPTION
When using the chromedriver-version input variable then github actions gives
a warning that a variable is used that was not defined.
Everything is working fine, but the warning can be avoided by adding the
inputs to the action.yml.