### PR TITLE
Speed up/enhance setup-chromedrive.sh

### DIFF
--- a/lib/setup-chromedriver.sh
+++ b/lib/setup-chromedriver.sh
@@ -2,78 +2,88 @@
 
 set -eo pipefail
 
+CURL="curl --silent --location --fail --retry 10"
+JSON_URL=https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
+
 VERSION=$1
 ARCH=$2
 
-if [ "$ARCH" == "linux64" ]; then
+if [[ "${ARCH}" =~ ^linux64 ]]; then
     CHROMEAPP=google-chrome
-    if ! type -a sudo > /dev/null 2>&1; then
-        apt-get update
-        apt-get install -y sudo
+    sudo=$(command -v sudo)
+    APP="${CHROMEAPP}"
+    if ! dpkg -s "${APP}" >/dev/null; then
+        ${sudo} apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A040830F7FAC5991
+        echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" | ${sudo} tee /etc/apt/sources.list.d/google.list
+        APP=google-chrome-stable
     fi
-    if ! type -a curl > /dev/null 2>&1; then
-        sudo apt-get update
-        sudo apt-get install -y curl
+    apps=()
+    test -z "${sudo}" && apps+=(sudo)
+    type -a curl > /dev/null 2>&1 || apps+=(curl)
+    type -a "${APP}" > /dev/null 2>&1 || apps+=("${APP}")
+    type -a jq > /dev/null 2>&1 || apps+=(jq)
+    type -a unzip > /dev/null 2>&1 || apps+=(unzip)
+    if (("${#apps[@]}")); then
+        echo "Installing ${apps[*]}..."
+        export DEBIAN_FRONTEND=noninteractive
+        ${sudo} apt-get update
+        ${sudo} apt-get install -y "${apps[@]}"
     fi
-    if ! type -a google-chrome > /dev/null 2>&1; then
-        # for debian
-        # curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64f.deb
-        # sudo apt install -y ./google-chrome-stable_current_amd64.deb
-        # CHROMEAPP=google-chrome-stable
-        sudo apt-get update
-        sudo apt-get install -y google-chrome
-    fi
-    if ! type -a jq > /dev/null 2>&1; then
-        sudo apt-get update
-        sudo apt-get install -y jq
-    fi
-    if ! type -a bc > /dev/null 2>&1; then
-        sudo apt-get update
-        sudo apt-get install -y bc
-    fi
-elif [ "$ARCH" == "mac64" ]; then
+fi
+
+if [[ "${ARCH}" =~ ^mac64 ]]; then
     CHROMEAPP="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 fi
 
-if [ "$VERSION" == "" ]; then
-    CHROME_VERSION=$("$CHROMEAPP" --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
+if [[ "${VERSION}" ]]; then
+    CHROME_VERSION=$(cut -d '.' -f 1 <<<"${VERSION}")
 else
-    CHROME_VERSION=$(echo "$VERSION" | cut -d '.' -f 1)
+    CHROME_VERSION=$("${CHROMEAPP}" --version | cut -f 3 -d ' ' | cut -d '.' -f 1)
 fi
+echo "CHROME_VERSION=${CHROME_VERSION}"
 
-UNDER115=$(echo "$CHROME_VERSION < 115" | bc)
-if [ "$UNDER115" -eq 1 ]; then
-    if [ "$VERSION" == "" ]; then
-        VERSION=$(curl --location --fail --retry 10 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION})
+if ((CHROME_VERSION < 115)); then
+    if [[ -z "${VERSION}" ]]; then
+        URL="https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}"
+        echo "Downloading ${URL}..."
+        VERSION=$(${CURL} "${URL}")
+        echo "VERSION=${VERSION}"
     fi
-    echo "Installing ChromeDriver $VERSION for $ARCH"
-
-    curl --location --fail --retry 10 -O https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_${ARCH}.zip
-    unzip -o -q chromedriver_${ARCH}.zip
+    echo "Installing ChromeDriver ${VERSION} for ${ARCH}"
+    URL="https://chromedriver.storage.googleapis.com/${VERSION}/chromedriver_${ARCH}.zip"
+    echo "Downloading ${URL}..."
+    ${CURL} -o chromedriver.zip "${URL}"
+    unzip -o -q chromedriver.zip
     sudo mv chromedriver /usr/local/bin/chromedriver
-    rm chromedriver_${ARCH}.zip
-else
-    if [ "$VERSION" == "" ]; then
-        VERSION=$("$CHROMEAPP" --version | cut -f 3 -d ' ')
-    fi
-    if [ "$ARCH" == "mac64" ]; then
-        ARCH="mac-x64"
-    fi
-
-    echo "Installing ChromeDriver $VERSION for $ARCH"
-    URL=$(curl  --location --fail --retry 10 https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r ".versions[] | select(.version == \"${VERSION}\") | .downloads.chromedriver[] | select(.platform == \"${ARCH}\") | .url")
-    if [ "$URL" == "" ]; then
-        echo "Fallback to latest version of ChromeDriver for $ARCH"
-        VERSION=$(curl  --location --fail --retry 10 https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r ".versions[] | select(.version | startswith(\"$(echo $VERSION | cut -d '.' -f1-3).\")) | .version" | tail -1)
-        URL=$(curl  --location --fail --retry 10 https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq -r ".versions[] | select(.version == \"${VERSION}\") | .downloads.chromedriver[] | select(.platform == \"${ARCH}\") | .url")
-        echo "Installing ChromeDriver $VERSION for $ARCH"
-    fi
-    echo "Downloading $URL"
-    curl --location --fail --retry 10 -O "$URL"
-    unzip -o -q chromedriver-${ARCH}.zip
-    sudo mv chromedriver-${ARCH}/chromedriver /usr/local/bin/chromedriver
-    rm chromedriver-${ARCH}.zip
-    rm -r chromedriver-${ARCH}
+    rm -f chromedriver.zip
+    exit
 fi
 
+if [[ -z "${VERSION}" ]]; then
+    VERSION=$("${CHROMEAPP}" --version | cut -f 3 -d ' ')
+    echo "VERSION=${VERSION}"
+fi
+if [[ "${ARCH}" =~ ^mac64 ]]; then
+    ARCH="mac-x64"
+fi
 
+echo "Downloading ${JSON_URL}..."
+JSON=$(${CURL} "${JSON_URL}")
+JQ=".versions[] | select(.version == \"${VERSION}\") | .downloads.chromedriver[] | select(.platform == \"${ARCH}\") | .url"
+URL=$(jq -r "${JQ}" <<<"${JSON}")
+if [[ -z "${URL}" ]]; then
+    echo "Falling back to latest version of ChromeDriver for ${ARCH}"
+    VERSION3=$(cut -d '.' -f1-3 <<<"${VERSION}")
+    echo "VERSION3=${VERSION3}"
+    JQ2="[ .versions[] | select(.version | startswith(\"${VERSION3}.\")) ] | last | .version"
+    VERSION=$(jq -r "${JQ2}" <<<"${JSON}")
+    echo "VERSION=${VERSION}"
+    JQ3=".versions[] | select(.version == \"${VERSION}\") | .downloads.chromedriver[] | select(.platform == \"${ARCH}\") | .url"
+    URL=$(jq -r "${JQ3}" <<<"${JSON}")
+fi
+echo "Installing ChromeDriver ${VERSION} for ${ARCH}"
+echo "Downloading ${URL}..."
+${CURL} -o chromedriver.zip "${URL}"
+unzip -o -q chromedriver.zip
+sudo mv "chromedriver-${ARCH}/chromedriver" /usr/local/bin/chromedriver
+rm -fr chromedriver.zip chromedriver-*


### PR DESCRIPTION
Only download URLs once
Only call apt-get install once, if needed
Install Chrome on Debian and derivatives
Remove dependency on bc
Remove duplicate code
Fix all shellcheck issues
Add debug output, where applicable
**Edit**: Replace `echo foo | bar`s with `bar <<<foo`



