### PR TITLE
Remove macos-12 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
           - macos-latest
           - macos-14
           - macos-13
-          - macos-12
         branch:
           # - 'master'
           - 'now'
@@ -99,7 +98,6 @@ jobs:
           - macos-latest
           - macos-14
           - macos-13
-          - macos-12
         branch:
           # - 'master'
           - 'now'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action sets up a [ChromeDriver](https://chromedriver.chromium.org/) for use
 ## OS/Platform support
 
 - ubuntu-latest, ubuntu-24.04, ubuntu-22.04 and ubuntu-20.04
-- macos-latest, macos-14, macos-13 and macos-12
+- macos-latest, macos-14 and macos-13
 - windows-latest, windows-2022 and windows-2019
 
 # Usage


### PR DESCRIPTION
This pull request includes updates to the supported macOS versions in the GitHub Actions workflow and documentation. The most important changes are the removal of macOS-12 from the list of supported versions.

Updates to supported macOS versions:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L32): Removed `macos-12` from the list of operating systems in the `jobs` section. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L32) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L102)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13): Updated the OS/Platform support section to remove `macos-12` from the list of supported macOS versions.