### PR TITLE
Remove unused imports and redundant search steps in chromedriver test

### DIFF
--- a/__tests__/chromedriver.ts
+++ b/__tests__/chromedriver.ts
@@ -1,15 +1,10 @@
-import { Builder, Capabilities, until, By, Key } from "selenium-webdriver";
+import { Builder, Capabilities, until } from "selenium-webdriver";
 (async () => {
   const timeout = 30000;
   const driver = new Builder().withCapabilities(Capabilities.chrome()).build();
   try {
     await driver.get("https://google.com");
     await driver.wait(until.titleContains("Google"), timeout);
-    console.log(await driver.getTitle());
-
-    const searchBox = await driver.findElement(By.name("q"));
-    await searchBox.sendKeys("ChromeDriver", Key.RETURN);
-    await driver.wait(until.titleContains("ChromeDriver"), timeout);
     console.log(await driver.getTitle());
   } finally {
     driver.quit();


### PR DESCRIPTION
This pull request includes changes to the `__tests__/chromedriver.ts` file, which streamline the test script by removing unnecessary imports and code.

Code simplification:

* Removed unused imports `By` and `Key` from the `selenium-webdriver` package.
* Removed code related to finding the search box and sending keys to it, simplifying the test script to only check the title of the Google homepage.