### PR TITLE
chore(ci): remove support for ubuntu-20.04 in workflows and documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-latest
           - macos-14
           - macos-13
@@ -94,7 +93,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-latest
           - macos-14
           - macos-13

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action sets up a [ChromeDriver](https://chromedriver.chromium.org/) for use
 
 ## OS/Platform support
 
-- ubuntu-latest, ubuntu-24.04, ubuntu-22.04 and ubuntu-20.04
+- ubuntu-latest, ubuntu-24.04 and ubuntu-22.04
 - macos-latest, macos-14 and macos-13
 - windows-latest, windows-2022 and windows-2019
 


### PR DESCRIPTION
This pull request updates the supported operating systems by removing Ubuntu 20.04 from the test configurations and documentation.

### Updates to supported operating systems:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L28): Removed Ubuntu 20.04 from the list of operating systems in two separate job configurations. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L28) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L97)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12): Updated the supported OS/platform list to exclude Ubuntu 20.04, reflecting the changes in the workflow configuration.