### PR TITLE
chore: Bump Ubuntu version used by test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04, macos-latest, macos-11 ]
+        os: [ ubuntu-latest, ubuntu-24.04, macos-latest, macos-11 ]
         branch:
           # - 'master'
           - 'now'
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04, macos-latest, macos-11 ]
+        os: [ ubuntu-latest, ubuntu-24.04, macos-latest, macos-11 ]
         branch:
           # - 'master'
           - 'now'


### PR DESCRIPTION
Asana ticket: [🚲 Ubuntu 20.04 runners being discontinued](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209410795125944?focus=true)

Will tag with a new version once this PR is merged.