### PR TITLE
chore: remove deprecated macos-13 from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
           - macos-latest
           - macos-15
           - macos-14
-          - macos-13
         branch:
           # - 'master'
           - 'now'
@@ -93,7 +92,6 @@ jobs:
           - macos-latest
           - macos-15
           - macos-14
-          - macos-13
         branch:
           # - 'master'
           - 'now'

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ steps:
 | Platform    | Versions                                          |
 |-------------|---------------------------------------------------|
 | **Ubuntu**  | `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`   |
-| **macOS**   | `macos-latest`, `macos-25 , macos-14`, `macos-13` |
+| **macOS**   | `macos-latest`, `macos-15`, `macos-14`            |
 | **Windows** | `windows-latest`, `windows-2025 , windows-2022`   |
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary
- Remove `macos-13` from GitHub Actions test matrix (deprecated by GitHub)
- Fix typo in README: `macos-25` → `macos-15`
- Update platform support documentation

## Test plan
- [x] Verify CI workflow runs successfully without macos-13
- [x] Confirm documentation accurately reflects supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)