### PR TITLE
chore(ci): 全ワークフローの外部アクションを SHA 固定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Supply-chain hardening: pin the marketplace to a specific commit (anthropics/claude-code v2.1.158).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,13 +30,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           # FIXME https://github.com/nanasess/setup-chromedriver/issues/229
           # - '114.0.5735.90'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - if: startsWith(matrix.os, 'ubuntu')
       run: echo 'CHROMEAPP=google-chrome' >> $GITHUB_ENV
     - if: startsWith(matrix.os, 'macos')
@@ -96,7 +96,7 @@ jobs:
           # - 'master'
           - 'now'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - if: startsWith(matrix.os, 'ubuntu')
       run: echo 'CHROMEAPP=google-chrome' >> $GITHUB_ENV
     - if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
           # - 'master'
           - 'now'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - shell: pwsh
       run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - run: yarn install --frozen-lockfile
@@ -79,7 +79,7 @@ jobs:
           # - 'master'
           - 'now'
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     - shell: pwsh
       run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary

サプライチェーン強化のため、ワークフローのサードパーティアクション参照を可変タグから現行タグが指すコミット SHA に固定しました。#449 で `code-review` プラグイン marketplace を SHA 固定したのと同方針です。

## Changes

| アクション | 変更前 | 変更後 | 対象ファイル |
|---|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` (v6.0.2) | claude.yml, claude-code-review.yml, test.yml, windows.yml |
| `anthropics/claude-code-action` | `@v1` | `@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1` | claude.yml, claude-code-review.yml |

### 据え置き（対象外）
- `nanasess/setup-chromedriver@master` … 自リポジトリの action を動作確認するためのもので、master 追従が必要（ユーザー指示により維持）。
- `uses: ./` … ローカルアクション参照。

末尾コメント (`# v6` 等) にメジャーバージョンを残し、Dependabot 等での更新追跡を可能にしています。SHA は各タグが現在指すコミットを GitHub API で取得して固定しました。

## Test plan

- [ ] `Test chromedriver on *NIX` / `Test chromedriver on Windows` が checkout の SHA 固定後も従来どおり成功すること
- [ ] (master マージ後) `@claude` メンションおよび自動レビューが claude-code-action の SHA 固定後も動作すること

## 補足

- `anthropics/claude-code-action` を SHA 固定すると `@v1` の自動パッチ追従はされなくなります（意図的なトレードオフ）。更新は Dependabot もしくは手動で SHA を差し替えてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフローのアクション参照をより厳密に固定し、CI／テスト／レビュー関連ジョブの実行を再現性高くしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->