### PR TITLE
fix(ci): marketplace URL の無効な #sha 固定を除去

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,9 +34,10 @@ jobs:
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Supply-chain hardening: pin the marketplace to a specific commit (anthropics/claude-code v2.1.158).
-          # Bump this SHA deliberately when updating the code-review plugin.
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git#295dee881d0e1c1d0cd22fe171e4c1d07118fb04'
+          # NOTE: plugin_marketplaces only accepts a plain Git URL; a `#<sha>` suffix
+          # is rejected ("Invalid marketplace URL format"), so the marketplace cannot
+          # be pinned to a commit here and tracks the default branch HEAD.
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

`claude-code-review.yml` の `plugin_marketplaces` に付与した `#<commit-sha>` が claude-code-action に受理されず、`Invalid marketplace URL format` で **全 PR の自動レビューが失敗**していたため修正します。

## 原因

`plugin_marketplaces` 入力は **プレーンな Git URL のみ** を受け付ける仕様で、`#<sha>` のような ref 指定はサポートされていません（公式 action.yml / usage.md で確認）。#449 で行った marketplace の SHA 固定はこの仕様に反しており、master 上で恒常的にレビューが落ちる状態になっていました。

実際のエラーログ（PR #446 の run より）:
\`\`\`
Action failed with error: Invalid marketplace URL format:
https://github.com/anthropics/claude-code.git#295dee881d0e1c1d0cd22fe171e4c1d07118fb04
\`\`\`

なお `actions/checkout` / `anthropics/claude-code-action` の SHA 固定（#450）は正常に動作しており（ログ上 DL 成功・OIDC 通過）、本件とは無関係です。

## Changes

- `plugin_marketplaces` から `#<commit-sha>` を除去し、プレーン URL に戻す
- `plugin_marketplaces` は ref 固定不可である旨をコメントで明記

## トレードオフ

- marketplace は固定できずデフォルトブランチ HEAD を追従します（サプライチェーン指摘 #3 は plugin_marketplaces の仕様上、本方式では解消不可）。
- プラグイン方式自体は維持します。

## Test plan

- [ ] master マージ後、任意の PR で `Claude Code Review` が `Invalid marketplace URL format` を出さずに起動すること
- [ ] checkout / claude-code-action の SHA 固定が引き続き機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフロー設定を更新しました。AI コード レビュー機能が使用するプラグイン マーケットプレイス設定を変更し、特定バージョンではなくデフォルトブランチの最新版を自動で追跡するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->