### PR TITLE
test(ci): add container compatibility test (#32 / #243)

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,0 +1,98 @@
+name: "Test chromedriver in containers"
+
+# Compatibility test for running the action inside a `container:` image.
+#
+# Several issues report failures when the action is used from a container
+# (e.g. ruby / elixir / minimal Debian images) because those images lack the
+# prerequisites the action assumes on a GitHub-hosted runner:
+#
+#   - #32  (elixir:*-slim): `sudo: command not found`, and google-chrome missing
+#   - #243 (ruby:3.2.2):    fails because container dependencies are missing
+#
+# This workflow encodes the *documented workaround* (install the prerequisites
+# and Google Chrome up front) and proves that, with that workaround in place,
+# the action succeeds across common container images.
+#
+# It is `workflow_dispatch`-only (on-demand) because it is comparatively slow
+# and runs against external package repositories. Use the `ref` input to pick
+# which version of the action to exercise:
+#   - `master`    : current shell-based implementation (default)
+#   - `issue-159` : the native TypeScript rewrite (PR #446)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Action ref to test (branch/tag), e.g. master or issue-159"
+        required: false
+        default: "master"
+
+jobs:
+  container-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - "ruby:3.2.2"        # #243 reporter's image
+          - "ruby:latest"
+          - "elixir:slim"       # #32 reporter's image class
+          - "node:slim"         # minimal Debian (no git/curl/gnupg by default)
+          - "debian:stable-slim"
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      # ----------------------------------------------------------------------
+      # Workaround step 1: install the prerequisites the action assumes.
+      #
+      # These run BEFORE actions/checkout, because checkout needs `git`, which
+      # the *-slim images do not ship. The remaining packages (sudo, gnupg,
+      # curl, unzip, jq, wget, ca-certificates) cover both the shell and the
+      # TypeScript implementations of the action.
+      # ----------------------------------------------------------------------
+      - name: Install container prerequisites (workaround for #32 / #243)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git sudo gnupg ca-certificates curl unzip jq wget
+
+      # ----------------------------------------------------------------------
+      # Workaround step 2: install Google Chrome.
+      #
+      # Containers do not ship google-chrome, so version auto-detection has
+      # nothing to read. Install the stable channel via the modern signed-by
+      # keyring scheme. (Recommends are kept on purpose so the runtime shared
+      # libraries Chrome needs are pulled in.)
+      # ----------------------------------------------------------------------
+      - name: Install Google Chrome
+        run: |
+          wget -q -O- https://dl.google.com/linux/linux_signing_key.pub \
+            | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+            > /etc/apt/sources.list.d/google-chrome.list
+          apt-get update
+          apt-get install -y google-chrome-stable
+
+      # Check out the requested ref so `uses: ./` exercises that version of the
+      # action code (`uses:` cannot take an expression for its path/ref).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: nanasess/setup-chromedriver
+          ref: ${{ inputs.ref }}
+
+      - name: Run setup-chromedriver
+        uses: ./
+        with:
+          chromeapp: google-chrome
+
+      # Smoke test: prove both binaries installed and are runnable inside the
+      # container. `--version` exercises the install path and shared-library
+      # availability without needing a display server.
+      - name: Verify
+        env:
+          IMAGE: ${{ matrix.image }}
+          REF: ${{ inputs.ref }}
+        run: |
+          echo "Image: $IMAGE / ref: $REF"
+          google-chrome --version
+          chromedriver --version

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,6 +1,6 @@
 name: "Test chromedriver in containers"
 
-# Compatibility test for running the action inside a `container:` image.
+# Compatibility gate for running the action inside a `container:` image.
 #
 # Several issues report failures when the action is used from a container
 # (e.g. ruby / elixir / minimal Debian images) because those images lack the
@@ -10,23 +10,27 @@ name: "Test chromedriver in containers"
 #   - #243 (ruby:3.2.2):    fails because container dependencies are missing
 #
 # This workflow encodes the *documented workaround* (install the prerequisites
-# and Google Chrome up front) and proves that, with that workaround in place,
-# the action succeeds across common container images.
-#
-# The `ref` matrix axis exercises both implementations of the action:
-#   - `master`    : current shell-based implementation
-#   - `issue-159` : the native TypeScript rewrite (PR #446)
-#
-# `workflow_dispatch` is kept for on-demand runs once this lands on the default
-# branch. The scoped `push` trigger lets the workflow be validated from its own
-# feature branch (a workflow_dispatch-only workflow cannot be dispatched until
-# it exists on the default branch).
+# and Google Chrome up front, and pass `chromeapp: google-chrome-stable`) and
+# proves that, with that workaround in place, the action succeeds across common
+# container images. `uses: ./` exercises the action code of the current
+# commit, so it gates pushes / PRs the same way test.yml does.
 
 on:
-  workflow_dispatch:
   push:
     branches:
-      - "test/container-compatibility"
+      - "*"
+    tags:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  workflow_dispatch:
 
 jobs:
   container-test:
@@ -35,14 +39,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - "ruby:3.2.2"        # #243 reporter's image
-          - "ruby:latest"
+          - "ruby:3.2.2"        # #243 reporter's image (Debian bullseye)
+          - "ruby:latest"       # Debian bookworm (apt-key removed)
           - "elixir:slim"       # #32 reporter's image class
           - "node:slim"         # minimal Debian (no git/curl/gnupg by default)
           - "debian:stable-slim"
-        ref:
-          - "master"            # current shell-based implementation
-          - "issue-159"         # native TypeScript rewrite (PR #446)
     container:
       image: ${{ matrix.image }}
     steps:
@@ -77,12 +78,9 @@ jobs:
           apt-get update
           apt-get install -y google-chrome-stable
 
-      # Check out the requested ref so `uses: ./` exercises that version of the
-      # action code (`uses:` cannot take an expression for its path/ref).
+      # Check out the current commit so `uses: ./` exercises this revision of
+      # the action (gating pushes / PRs).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: nanasess/setup-chromedriver
-          ref: ${{ matrix.ref }}
 
       # Pass the *package name we installed* (google-chrome-stable) as chromeapp.
       # The action runs `dpkg -s <chromeapp>` to decide whether Chrome is
@@ -102,8 +100,7 @@ jobs:
       - name: Verify
         env:
           IMAGE: ${{ matrix.image }}
-          REF: ${{ matrix.ref }}
         run: |
-          echo "Image: $IMAGE / ref: $REF"
+          echo "Image: $IMAGE"
           google-chrome-stable --version
           chromedriver --version

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -13,19 +13,20 @@ name: "Test chromedriver in containers"
 # and Google Chrome up front) and proves that, with that workaround in place,
 # the action succeeds across common container images.
 #
-# It is `workflow_dispatch`-only (on-demand) because it is comparatively slow
-# and runs against external package repositories. Use the `ref` input to pick
-# which version of the action to exercise:
-#   - `master`    : current shell-based implementation (default)
+# The `ref` matrix axis exercises both implementations of the action:
+#   - `master`    : current shell-based implementation
 #   - `issue-159` : the native TypeScript rewrite (PR #446)
+#
+# `workflow_dispatch` is kept for on-demand runs once this lands on the default
+# branch. The scoped `push` trigger lets the workflow be validated from its own
+# feature branch (a workflow_dispatch-only workflow cannot be dispatched until
+# it exists on the default branch).
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Action ref to test (branch/tag), e.g. master or issue-159"
-        required: false
-        default: "master"
+  push:
+    branches:
+      - "test/container-compatibility"
 
 jobs:
   container-test:
@@ -39,6 +40,9 @@ jobs:
           - "elixir:slim"       # #32 reporter's image class
           - "node:slim"         # minimal Debian (no git/curl/gnupg by default)
           - "debian:stable-slim"
+        ref:
+          - "master"            # current shell-based implementation
+          - "issue-159"         # native TypeScript rewrite (PR #446)
     container:
       image: ${{ matrix.image }}
     steps:
@@ -78,7 +82,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: nanasess/setup-chromedriver
-          ref: ${{ inputs.ref }}
+          ref: ${{ matrix.ref }}
 
       - name: Run setup-chromedriver
         uses: ./
@@ -91,7 +95,7 @@ jobs:
       - name: Verify
         env:
           IMAGE: ${{ matrix.image }}
-          REF: ${{ inputs.ref }}
+          REF: ${{ matrix.ref }}
         run: |
           echo "Image: $IMAGE / ref: $REF"
           google-chrome --version

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -84,10 +84,17 @@ jobs:
           repository: nanasess/setup-chromedriver
           ref: ${{ matrix.ref }}
 
+      # Pass the *package name we installed* (google-chrome-stable) as chromeapp.
+      # The action runs `dpkg -s <chromeapp>` to decide whether Chrome is
+      # present; passing `google-chrome` (the binary alias, not the package
+      # name) makes that check fail and forces the action into its apt-key
+      # install path -- which is broken on Debian 12+ where `apt-key` is removed
+      # (the root cause of #243 for bookworm-based images). Matching the package
+      # name keeps the action on the "already installed" path.
       - name: Run setup-chromedriver
         uses: ./
         with:
-          chromeapp: google-chrome
+          chromeapp: google-chrome-stable
 
       # Smoke test: prove both binaries installed and are runnable inside the
       # container. `--version` exercises the install path and shared-library
@@ -98,5 +105,5 @@ jobs:
           REF: ${{ matrix.ref }}
         run: |
           echo "Image: $IMAGE / ref: $REF"
-          google-chrome --version
+          google-chrome-stable --version
           chromedriver --version

--- a/README.md
+++ b/README.md
@@ -80,6 +80,63 @@ steps:
       chromeapp: chrome-beta
 ```
 
+### Usage in a Container
+
+When a job runs inside a `container:` image (e.g. `ruby`, `elixir`, `node:slim`,
+`debian:slim`), the action **cannot install Google Chrome or the system
+prerequisites for you** — minimal images ship without `sudo`, `git`, `gnupg`,
+`unzip`, etc., and recent Debian releases (12 "bookworm" and later) no longer
+provide `apt-key`. You must prepare the container yourself before calling the
+action (see issues [#32](https://github.com/nanasess/setup-chromedriver/issues/32)
+and [#243](https://github.com/nanasess/setup-chromedriver/issues/243)).
+
+Three things are required:
+
+1. **Install the prerequisites _before_ `actions/checkout`** (checkout itself
+   needs `git`, which slim images do not ship):
+   `git sudo gnupg ca-certificates curl unzip jq wget`
+2. **Install Google Chrome yourself** using the modern `signed-by` keyring
+   scheme (the action's built-in Chrome install relies on the removed
+   `apt-key`).
+3. **Pass `chromeapp: google-chrome-stable`** — the action checks
+   `dpkg -s <chromeapp>`, so it must match the installed _package_ name
+   (`google-chrome-stable`), not the `google-chrome` binary alias. Otherwise the
+   check fails and the action falls back to the broken `apt-key` install path.
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.2.2
+    steps:
+      # 1. Prerequisites (must run before checkout, since checkout needs git)
+      - name: Install container prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git sudo gnupg ca-certificates curl unzip jq wget
+
+      # 2. Install Google Chrome via the signed-by keyring scheme
+      - name: Install Google Chrome
+        run: |
+          wget -q -O- https://dl.google.com/linux/linux_signing_key.pub \
+            | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+            > /etc/apt/sources.list.d/google-chrome.list
+          apt-get update
+          apt-get install -y google-chrome-stable
+
+      - uses: actions/checkout@v4
+
+      # 3. Pass the installed package name as chromeapp
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromeapp: google-chrome-stable
+
+      - run: chromedriver --version
+```
+
 ## 🖥️ Platform Support
 
 | Platform    | Versions                                          |


### PR DESCRIPTION
## Overview

Adds a permanent `container-test.yml` workflow that verifies the action works when used inside a `container: image:`, and documents the required steps for container usage in the README.

Containers such as `ruby` / `elixir:slim` have long been reported as failing (#32 / #243). Until now we have responded to each report with "install sudo separately", but there was no CI to catch regressions. This PR **encodes that workaround and verifies it continuously**.

## Root cause of #243, confirmed live

In the first run (a ref-matrix variant), every image except `ruby:3.2.2` failed, which let us pin down two distinct causes:

1. **`apt-key` was removed in Debian 12 (bookworm) and later** — only the bullseye-based `ruby:3.2.2` succeeded before, while the bookworm-based images (`ruby:latest` / `elixir:slim` / `node:slim` / `debian:stable-slim`) failed with `apt-key: command not found`.
2. **Mismatch between the `chromeapp` value and the package name** — the action decides whether Chrome is present via `dpkg -s <chromeapp>`, so passing the binary alias `google-chrome` makes that check miss and forces the action down the broken apt-key install path.

## The established workaround (3 requirements)

1. Install prerequisites **before** `actions/checkout` (`git sudo gnupg ca-certificates curl unzip jq wget`) — checkout itself needs `git`, which slim images do not ship.
2. Install `google-chrome-stable` yourself using the `signed-by` keyring scheme (the action's built-in Chrome install relies on the removed `apt-key`).
3. Pass **`chromeapp: google-chrome-stable`** so it matches the installed package name and the action stays on the "already installed" path instead of the apt-key path.

## Changes

- `.github/workflows/container-test.yml` (new)
  - `on.push` / `on.pull_request` (`paths: ['**', '!*.md']`) + `workflow_dispatch`, mirroring `test.yml`
  - matrix: `ruby:3.2.2` / `ruby:latest` / `elixir:slim` / `node:slim` / `debian:stable-slim` (covers both bullseye and bookworm)
  - plain `actions/checkout` → `uses: ./` so it gates the actual pushed / PR code
  - smoke test via `google-chrome-stable --version` / `chromedriver --version`
- `README.md`: adds a "Usage in a Container" section documenting the 3 requirements above

## Verification

- During development, parity was confirmed end-to-end across 5 images × (master shell version / issue-159 TS version) = 10 jobs (all green), proving PR #446 (the TypeScript rewrite) behaves the same as the shell version in containers.
- The (B)-form run under the `pull_request` trigger for this PR: see this PR's Checks (all 5 jobs green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)