### PR TITLE
test(ci): add legacy (<115) and version-resolution smoke tests (#229)

### DIFF
--- a/.github/workflows/legacy-test.yml
+++ b/.github/workflows/legacy-test.yml
@@ -1,0 +1,92 @@
+name: "Test legacy ChromeDriver (<115)"
+
+# Install-only smoke test for the legacy ChromeDriver path (Chrome < 115),
+# which uses the old chromedriver.storage.googleapis.com API instead of the
+# Chrome for Testing JSON endpoints. See #229.
+#
+# Why install-only (no browser launch): the existing E2E (__tests__/chromedriver.ts)
+# starts a real browser session against the runner's *current* Chrome. A <115
+# driver cannot drive a modern Chrome ("only supports Chrome version N"), so
+# that E2E always fails for a pinned legacy version -- which is exactly why the
+# 114 matrix entry is commented out in test.yml (#229). This workflow instead
+# verifies what the action is actually responsible for: downloading and
+# installing the legacy binary, then reporting its version.
+#
+# `uses: ./` exercises the action code of the current commit (shell version on
+# master, TypeScript version once merged into issue-159).
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  workflow_dispatch:
+
+jobs:
+  legacy:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - macos-latest
+          - macos-15
+          - macos-14
+          - windows-latest
+          - windows-2025
+          - windows-2022
+    env:
+      # Chrome 114 is the last < 115 release; the action resolves this through
+      # the legacy chromedriver.storage.googleapis.com API.
+      LEGACY_VERSION: "114.0.5735.90"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Windows: the action reads the installed Chrome's FileVersion up front,
+      # so chromeapp must point at the pre-installed Chrome even though the
+      # version is pinned. (Left empty on Linux/macOS, where the action falls
+      # back to its platform default.)
+      - if: runner.os == 'Windows'
+        shell: pwsh
+        run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
+      # macOS (Apple Silicon): the legacy API has no mac-arm64 build, so the
+      # action installs the x64 (mac64) chromedriver. Rosetta 2 is required to
+      # run an x64 binary on arm runners.
+      - if: runner.os == 'macOS'
+        run: softwareupdate --install-rosetta --agree-to-license
+
+      - uses: ./
+        with:
+          chromedriver-version: ${{ env.LEGACY_VERSION }}
+          chromeapp: ${{ env.CHROMEAPP }}
+
+      # Install-only smoke: confirm the legacy binary is installed and reports
+      # the expected version. No browser is launched (see the header comment).
+      - if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          chromedriver --version
+          chromedriver --version | grep -F "$LEGACY_VERSION"
+      - if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $out = chromedriver --version
+          Write-Output $out
+          if ($out -notmatch [regex]::Escape($Env:LEGACY_VERSION)) {
+            Write-Error "Expected $Env:LEGACY_VERSION, got: $out"
+            exit 1
+          }

--- a/.github/workflows/version-resolution-test.yml
+++ b/.github/workflows/version-resolution-test.yml
@@ -1,0 +1,96 @@
+name: "Test ChromeDriver version resolution"
+
+# Install-only smoke tests for the modern (>= 115) version-resolution branches
+# that the OS matrix in test.yml does not exercise:
+#
+#   - boundary: 115.0.5790.170  -> exact match in the Chrome for Testing JSON
+#     (confirms the `< 115` legacy/modern split is exclusive at the boundary).
+#   - fallback: 131.0.6778.999  -> no exact match; the action falls back to the
+#     `major.minor.build` (version3) prefix and picks the last matching version
+#     (131.0.6778.87). This `version3` fallback branch is otherwise untested.
+#
+# Like legacy-test.yml, these are install-only: the version is pinned, so no
+# Chrome of a matching version is needed and no browser is launched. We only
+# assert that `chromedriver --version` reports the expected version.
+#
+# `uses: ./` exercises the action code of the current commit (shell version on
+# master, TypeScript version once merged into issue-159).
+#
+# NOTE: a major-only input (e.g. `131`) is intentionally NOT covered here -- it
+# crashes the master PowerShell script on Windows (`"131".LastIndexOf('.')` is
+# -1, so `Substring(0, -1)` throws). That edge is fixed by the TypeScript
+# rewrite (#446) and is tracked separately.
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "**"
+      - "!*.md"
+  workflow_dispatch:
+
+jobs:
+  resolve:
+    name: "${{ matrix.os }} / ${{ matrix.case.version }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - macos-latest
+          - macos-15
+          - macos-14
+          - windows-latest
+          - windows-2025
+          - windows-2022
+        case:
+          # modern boundary: first version above the <115 legacy split
+          - version: "115.0.5790.170"
+            expect: "115.0.5790.170"
+          # version3 fallback: nonexistent patch -> last 131.0.6778.* (87)
+          - version: "131.0.6778.999"
+            expect: "131.0.6778."
+    env:
+      VERSION: ${{ matrix.case.version }}
+      EXPECT: ${{ matrix.case.expect }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Windows: the action reads the installed Chrome's FileVersion up front,
+      # so chromeapp must point at the pre-installed Chrome. (Left empty on
+      # Linux/macOS, where the action uses its platform default.)
+      - if: runner.os == 'Windows'
+        shell: pwsh
+        run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
+      - uses: ./
+        with:
+          chromedriver-version: ${{ matrix.case.version }}
+          chromeapp: ${{ env.CHROMEAPP }}
+
+      - if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          chromedriver --version
+          chromedriver --version | grep -F "$EXPECT"
+      - if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $out = chromedriver --version
+          Write-Output $out
+          if ($out -notmatch [regex]::Escape($Env:EXPECT)) {
+            Write-Error "Expected to contain '$Env:EXPECT', got: $out"
+            exit 1
+          }

--- a/lib/setup-chromedriver.ps1
+++ b/lib/setup-chromedriver.ps1
@@ -28,9 +28,9 @@ else
 
 if($chrome_majorversion -lt 115)
 {
-    $response = Invoke-WebRequest "http://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chrome_majorversion"
+    $response = Invoke-WebRequest "http://chromedriver.storage.googleapis.com/LATEST_RELEASE_$chrome_majorversion" -UseBasicParsing
     $version = $response.Content
-    Invoke-WebRequest "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip" -OutFile chromedriver_win32.zip
+    Invoke-WebRequest "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip" -OutFile chromedriver_win32.zip -UseBasicParsing
     Expand-Archive -Path chromedriver_win32.zip -DestinationPath C:\SeleniumWebDrivers\ChromeDriver -Force
     Remove-Item chromedriver_win32.zip
     Return 0
@@ -58,7 +58,7 @@ if (!$url)
 }
 Write-Output "Installing ChromeDriver $version for $arch"
 Write-Output "Downloading $url..."
-Invoke-WebRequest $url -OutFile chromedriver-win32.zip
+Invoke-WebRequest $url -OutFile chromedriver-win32.zip -UseBasicParsing
 Expand-Archive -Path chromedriver-win32.zip -Force
 Move-Item -Path .\chromedriver-win32\chromedriver-win32\chromedriver.exe -Destination C:\SeleniumWebDrivers\ChromeDriver -Force
 Remove-Item chromedriver-win32.zip

--- a/lib/setup-chromedriver.ps1
+++ b/lib/setup-chromedriver.ps1
@@ -3,6 +3,11 @@ Param(
     [string]$chromeapp
 )
 
+# Windows PowerShell 5.1's Invoke-WebRequest is drastically slowed by its
+# progress bar (it re-renders on every byte chunk), which makes the ChromeDriver
+# download take minutes in CI. Disabling it restores full-speed downloads.
+$ProgressPreference = 'SilentlyContinue'
+
 if([string]::IsNullOrEmpty($chromeapp))
 {
     $chromeapp = "C:\Program Files\Google\Chrome\Application\chrome.exe"


### PR DESCRIPTION
## Overview

Adds two standalone install-only smoke workflows that cover ChromeDriver version branches the OS matrix in `test.yml` does not exercise, across all 9 windows/macOS/Linux runners, plus a Windows fix discovered while running them.

- **`legacy-test.yml`** — the legacy path (Chrome < 115), tracked by #229.
- **`version-resolution-test.yml`** — modern (>= 115) boundary and `version3` fallback resolution.
- **`setup-chromedriver.ps1`** — Windows download fix (`-UseBasicParsing` + disabled progress bar).

Both workflows pin `chromedriver-version` and assert `chromedriver --version` **without launching a browser**, so no matching Chrome is required.

## Why install-only (no browser)

The existing E2E (`__tests__/chromedriver.ts`) launches a real browser session against the runner's *current* Chrome. A pinned `< 115` driver cannot drive a modern Chrome (`only supports Chrome version 114`), which is exactly why the `114.0.5735.90` matrix entry is commented out in `test.yml` (#229). The legacy install path itself works, and the binaries are still served (`LATEST_RELEASE_114` → `114.0.5735.90`; the `linux64` / `mac64` / `mac_arm64` / `win32` zips return HTTP 200). These workflows verify the action's actual responsibility — resolving, downloading and installing the correct binary.

## legacy-test.yml

- `chromedriver-version: 114.0.5735.90`, assert the reported version
- **macOS (Apple Silicon)**: the legacy API has no `mac-arm64` build, so the action installs the x64 (`mac64`) binary — Rosetta 2 is installed first
- **Windows**: the PowerShell script reads the installed Chrome `FileVersion` up front, so `chromeapp` is set to the pre-installed Chrome path

## version-resolution-test.yml

| Case | Input | Branch exercised |
|---|---|---|
| boundary | `115.0.5790.170` | exact match (confirms the `<115` split is exclusive at the boundary) |
| fallback | `131.0.6778.999` | no exact match → `version3` prefix → last `131.0.6778.*` (`131.0.6778.87`) |

A **major-only** input (e.g. `131`) is intentionally excluded: it crashes the master PowerShell script on Windows (`"131".LastIndexOf('.')` is `-1`, so `Substring(0, -1)` throws). That edge is fixed by the TypeScript rewrite (#446) and will be added once #446 is merged.

## Windows download fix (setup-chromedriver.ps1)

The first run surfaced that the **legacy** Windows jobs hung for ~11–15 minutes while Linux/macOS finished in seconds — and, decisively, the **modern** Windows jobs finished in ~20–37s. The difference localized the cause: the legacy block's `Invoke-WebRequest "...LATEST_RELEASE_$major"` was missing **`-UseBasicParsing`**, so Windows PowerShell 5.1 tried to parse the response with the Internet Explorer engine, which stalls on current Windows runner images where IE is gone. The modern block already used `-UseBasicParsing` (hence fast).

Fix: add `-UseBasicParsing` to the legacy `Invoke-WebRequest` calls (and the modern `-OutFile` download), and set `$ProgressPreference = 'SilentlyContinue'` to keep download progress rendering from slowing CI. After the fix, the legacy Windows jobs complete in 17–65s. (The TypeScript rewrite in #446 downloads via `@actions/tool-cache` and is unaffected.)

## Results (all green)

- `legacy-test`: 9/9 — Windows now 17s / 31s / 65s (was ~11–15 min)
- `version-resolution-test`: 18/18

## Plan

Validate against master (shell version) here; once green, reflect into issue-159 (#446) via *Update branch* so the TypeScript rewrite's legacy / resolution paths are covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)