### PR TITLE
chore: remove unnecessary version field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "setup-chromedriver",
-  "version": "2.0.0",
   "private": true,
   "description": "setup-chromedriver",
   "type": "module",


### PR DESCRIPTION
## Overview

Remove the `version` field from `package.json`.

## Background

This PR originally bumped the version for the v3.0.0 release, but investigation showed the `version` field is unnecessary, so the approach was changed to removal.

- **Optional per npm spec**: `private: true` is set, so the package is never published to npm (it is also absent from the registry — 404). The npm docs state that `name`/`version` are optional when you don't plan to publish.
- **Referenced nowhere**: `action.yml` does not read `version`, and it is not embedded in the ncc bundle (`dist/`).
- **Already decoupled from release tags**: at the `v2.0.0` tag the field was still `1.0.8`, and at `v2.4.0` it remained `2.0.0` — it was never kept in sync.

Release versions are managed via git tags (e.g. `v3.0.0`), so the misleading `version` field is removed.

### Survey of other major actions (no industry standard)

- No `version` field: `pnpm/action-setup` (`private: true`, same shape as this repo after removal), `docker/build-push-action`
- Has `version` but stale: `dorny/paths-filter` (`1.0.0` / latest tag `v3`), `ruby/setup-ruby` (`0.1.0` / `v1`)
- Keeps `version` roughly in sync: `actions/setup-node`, `actions/cache` (`private: true`), `actions/checkout`

## Verification

- `package.json` remains valid JSON after removal (verified with `node -e "require('./package.json')"`).
- No `dist/` rebuild required (the version is not included in the bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)