### PR TITLE
fix: split cooldown responsibilities to resolve Dependabot error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Dependabot は pnpm の minimumReleaseAge を認識しないため、ここで
+    # cooldown を設定し、まだインストールできない (= --frozen-lockfile が
+    # ERR_PNPM_NO_MATCHING_VERSION で失敗する) 新版で PR を作らせない。
+    # 不変条件: cooldown >= pnpm-workspace.yaml の minimumReleaseAge (1 日)。
+    # 余裕を持たせ、自動更新経路の供給網保護も厚くするため 3 日にする。
+    cooldown:
+      default-days: 3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,15 +2,19 @@
 # 単一パッケージでも pnpm の設定ファイルとして機能する。
 
 # 公開直後の新バージョンを採用しないクールダウン (分単位)。
-# 乗っ取り直後に公開された悪性バージョンの自動取り込みを防ぐ。4320 分 = 3 日。
-# 悪性版は公開後数時間〜数日で検知・yank される事が多いため 3 日確保する。
+# 乗っ取り直後に公開された悪性バージョンの自動取り込みを防ぐ。1440 分 = 1 日。
+# Dependabot は pnpm の minimumReleaseAge を認識せず、窓内の新版で即 PR を
+# 作るため install (--frozen-lockfile) が ERR_PNPM_NO_MATCHING_VERSION で
+# 失敗する。そこで pnpm 側はインストール可能になる下限の 1 日に抑え、
+# PR 作成の遅延は Dependabot 側の cooldown (.github/dependabot.yml, 3 日)
+# に任せる。cooldown >= この minimumReleaseAge を満たす限り install は通る。
 # 緊急のセキュリティ修正を即時採用したい場合は minimumReleaseAgeExclude で
 # 対象パッケージを個別に除外できる。
-minimumReleaseAge: 4320
+minimumReleaseAge: 1440
 
 # クールダウンの適用除外。
 # browserslist エコシステムのブラウザ互換データ群はほぼ毎日リリースされる
-# ため、3 日クールダウンだと解決のたびに窓内の最新版を掴んで CI の
+# ため、クールダウンだと解決のたびに窓内の最新版を掴んで CI の
 # --frozen-lockfile が失敗する (pnpm の minimumReleaseAge は古い版へ
 # 自動降格せず検証で弾く)。これらは dev 専用・データのみで dist には
 # 一切バンドルされない (公開される action に含まれない) ため、供給網


### PR DESCRIPTION
## Summary

Fixes the Dependabot error caused by the pnpm `minimumReleaseAge: 4320` (3 days) introduced in #456. Dependabot does not understand pnpm's `minimumReleaseAge`, so it opened PRs for new versions still inside the cooldown window, and the CI on those PRs failed with `ERR_PNPM_NO_MATCHING_VERSION` during `pnpm install --frozen-lockfile`.

This is resolved by splitting the cooldown into two distinct responsibilities:

- **pnpm `minimumReleaseAge`**: the safety net defining the *lower bound at which a version becomes installable*. Reduced to 1440 minutes (1 day).
- **Dependabot `cooldown`**: the *delay before an update PR is opened*. Set to 3 days.

By keeping the invariant **`cooldown >= minimumReleaseAge` (3 days ≥ 1 day)**, by the time Dependabot opens a PR the version has already cleared pnpm's window, so `install` succeeds.

## Changes

- `pnpm-workspace.yaml`: change `minimumReleaseAge` from `4320` (3 days) to `1440` (1 day); update the comment to match reality.
- `.github/dependabot.yml`: add `cooldown.default-days: 3` to the npm ecosystem.
- `minimumReleaseAgeExclude` (the daily-release group such as `caniuse-lite`) is kept as-is.

## Test plan

- [ ] `pnpm install --frozen-lockfile` succeeds on Dependabot dependency-update PRs (no recurrence of `ERR_PNPM_NO_MATCHING_VERSION`)
- [ ] The Dependabot config is recognized as valid (the error clears under Insights → Dependency graph → Dependabot)

## Related

- Adjusts the `minimumReleaseAge: 4320` introduced in #456
- Reference: [dependabot-core#13165](https://github.com/dependabot/dependabot-core/issues/13165) (conflict between pnpm `minimumReleaseAge` and Dependabot cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他（Chores）**
  * 依存関係の更新ポリシーを調整しました。新バージョン採用までの待機期間と更新提案のタイミングが変更されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->