### PR TITLE
docs(readme): announce @master deprecation and main migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ That's it! ChromeDriver will be installed and added to your PATH.
 > replacement. `@v2` remains available as the previous, shell-based
 > implementation for existing workflows that prefer to stay pinned.
 
+> [!WARNING]
+> **`@master` is deprecated** — the default branch is now `main`. If your
+> workflow references the action by the `master` branch
+> (`uses: nanasess/setup-chromedriver@master`), please migrate to `@v3` (or pin
+> a full commit SHA). The `master` branch is frozen, emits a deprecation
+> warning at runtime, and will not receive future updates.
+
 > [!TIP]
 > **Supply-chain hardening** — mutable tags like v3 can be repointed at any
 > time, so for security-sensitive workflows pin the action to a full-length


### PR DESCRIPTION
## Overview

Add a README notice that the default branch is now `main` and that referencing the action via the `master` branch (`@master`) is deprecated.

## Background

The default branch was switched from `master` to `main`. A GitHub search shows roughly **1,000 workflows still reference `@master`**. Dependabot does **not** migrate branch refs to release tags, so these users must be guided manually.

This complements the runtime `core.warning` added on the `master` branch (#463) by documenting the migration path for new and existing users.

## Change

- Adds a `> [!WARNING]` block in the Quick Start section pointing `@master` users to `@v3` (or a pinned SHA), and stating that `master` is frozen / warning-only / no longer updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* README の Quick Start セクションに警告を追加しました。`@master` ブランチが非推奨となり、デフォルトが `main` に変更されました。`@v3` またはフルのコミット SHA への移行をお勧めします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->