### PR TITLE
feat: auto-regenerate and commit dist/lib for Dependabot npm PRs

### DIFF
--- a/.github/workflows/dependabot-dist.yml
+++ b/.github/workflows/dependabot-dist.yml
@@ -1,0 +1,58 @@
+name: "Update dist for Dependabot"
+
+# Dependabot の npm PR では package.json / pnpm-lock.yaml だけが更新され、
+# ランタイム依存を束ねた dist/index.js は再生成されない (dependabot は
+# ビルド成果物を生成しない)。本番のタグ参照 (@v3 等) はコミット済み dist を
+# 直接実行するため、依存更新を本番へ届けるには dist の再生成が要る。
+# このワークフローは dependabot の npm ブランチへの push を受けて dist を
+# 再生成し、差分があれば同じブランチへ追記コミットする。
+on:
+  push:
+    branches:
+      # npm エコシステムのブランチのみ。github-actions の更新
+      # (dependabot/github_actions/**) は dist に影響しないので対象外。
+      - "dependabot/npm_and_yarn/**"
+
+# dist をブランチへ push し返すため contents:write が要る。dependabot 起因の
+# run では GITHUB_TOKEN は既定で read-only なので、ここで明示的に付与する。
+permissions:
+  contents: write
+
+jobs:
+  update-dist:
+    # dependabot 以外による push では動かさない安全弁。
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # push されたブランチを (detached ではなく) チェックアウトして
+          # push し返せるようにする。
+          ref: ${{ github.ref_name }}
+          # 既定の GITHUB_TOKEN で push する。GITHUB_TOKEN による push は
+          # 新たな workflow を再トリガーしないため、dist の追記コミットが
+          # このワークフロー自身を再起動する無限ループを自動的に防ぐ。
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm package
+      - name: Commit regenerated dist
+        # ブランチ名を run スクリプトに直接展開せず env 経由で渡し、
+        # 万一のシェルインジェクションを防ぐ。
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet -- dist lib; then
+            echo "No changes in dist/lib; skipping commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add dist lib
+          git commit -m 'build: regenerate dist/lib for dependency update'
+          git push origin "HEAD:$BRANCH"


### PR DESCRIPTION
## Background

Dependabot only updates `package.json` / `pnpm-lock.yaml` and does not regenerate `dist/index.js`, which bundles the runtime dependencies. Since the published tags (`@v3`, etc.) execute the committed `dist/index.js` directly, dependency updates were never reaching production and kept accumulating (discovered while investigating PR #467 — `typed-rest-client` was still bundled at 2.x).

This drift is hard to notice because the CI test suite rebuilds dist on every run (`pnpm build` → `pnpm package`), so the stale committed dist never turns CI red.

## Change

Adds a workflow (`.github/workflows/dependabot-dist.yml`) that triggers on pushes to `dependabot/npm_and_yarn/**`, regenerates dist, and—if there is a diff—commits it back to the same branch.

## Design decisions

- **Scoped to the npm ecosystem**: `dependabot/github_actions/**` does not affect dist, so it is excluded.
- **Push with GITHUB_TOKEN**: pushes made with GITHUB_TOKEN do not re-trigger workflows, so the dist commit cannot cause an infinite loop. No external token/App is introduced, keeping the supply chain minimal.
- **Explicit `permissions: contents: write`**: Dependabot-triggered runs default to a read-only GITHUB_TOKEN.
- **`if: github.actor == 'dependabot[bot]'`**: a guard so it never runs for non-Dependabot pushes.
- **Branch name passed via env**: `github.ref_name` is passed through an env var rather than interpolated directly into the `run` script, preventing shell injection.
- **Same pinned action SHAs / Node 24** as the existing workflows.

## Known trade-off

Commits pushed with GITHUB_TOKEN do not re-trigger the push-triggered test CI. However, since CI regenerates dist on every run, the committed dist contents do not affect test results, so the impact is expected to be small. If the repo later enforces required status checks on the latest SHA, switch to a GitHub App token approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)