### PR TITLE
chore: remove redundant direct jest-circus devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@vercel/ncc": "^0.38.4",
     "@jest/globals": "^30.3.0",
     "jest": "^30.3.0",
-    "jest-circus": "^30.3.0",
     "prettier": "^3.8.1",
     "selenium-webdriver": "^4.39.0",
     "ts-jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       jest:
         specifier: ^30.3.0
         version: 30.4.2(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3))
-      jest-circus:
-        specifier: ^30.3.0
-        version: 30.4.2
       prettier:
         specifier: ^3.8.1
         version: 3.8.3


### PR DESCRIPTION
## Summary

Remove `jest-circus` from `devDependencies`.

## Background (#447)

- `jest.config.js` does not set a `testRunner`. Since Jest 27+, the default test runner is `jest-circus/runner`, and the version bundled with Jest itself is what actually runs.
- There are no references to `jest-circus` / `circus` anywhere in the source or config (only the `devDependencies` entry in `package.json`).
- Keeping the direct dependency lets Dependabot bump it independently of Jest itself (e.g. #428), producing low-value update PRs and a mismatched state (`jest@N` + `jest-circus@M`).

## Changes

- Remove `jest-circus` from `package.json`
- Update `pnpm-lock.yaml`

No `lib/` / `dist/` regeneration is needed since this only touches a devDependency.

## Verification

```
pnpm test
Test Suites: 1 skipped, 7 passed, 7 of 8 total
Tests:       4 skipped, 97 passed, 101 total
```

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 開発環境の依存関係を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->