### PR TITLE
ci: drop the @master parity gate and orchestrate CI via a reusable-workflow main.yml

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -22,6 +22,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# 最小権限: checkout / 依存導入 / アクション実行のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   container-test:
     runs-on: ubuntu-latest
@@ -71,6 +75,8 @@ jobs:
       # Check out the current commit so `uses: ./` exercises this revision of
       # the action (gating pushes / PRs).
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # Pass the *package name we installed* (google-chrome-stable) as chromeapp.
       # The action runs `dpkg -s <chromeapp>` to decide whether Chrome is

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -14,22 +14,12 @@ name: "Test chromedriver in containers"
 # proves that, with that workaround in place, the action succeeds across common
 # container images. `uses: ./` exercises the action code of the current
 # commit, so it gates pushes / PRs the same way test.yml does.
+#
+# Reusable workflow: orchestrated by main.yml. workflow_dispatch is kept so this
+# suite can still be run on its own from the Actions UI.
 
 on:
-  push:
-    branches:
-      - "*"
-    tags:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
-  pull_request:
-    branches:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/legacy-test.yml
+++ b/.github/workflows/legacy-test.yml
@@ -22,6 +22,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# 最小権限: checkout / アクション実行のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   legacy:
     runs-on: ${{ matrix.os }}
@@ -44,6 +48,8 @@ jobs:
       LEGACY_VERSION: "114.0.5735.90"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # Windows: the action reads the installed Chrome's FileVersion up front,
       # so chromeapp must point at the pre-installed Chrome even though the

--- a/.github/workflows/legacy-test.yml
+++ b/.github/workflows/legacy-test.yml
@@ -12,24 +12,14 @@ name: "Test legacy ChromeDriver (<115)"
 # verifies what the action is actually responsible for: downloading and
 # installing the legacy binary, then reporting its version.
 #
-# `uses: ./` exercises the action code of the current commit (shell version on
-# master, TypeScript version once merged into issue-159).
+# `uses: ./` exercises the action code of the current commit (the native
+# TypeScript implementation).
+#
+# Reusable workflow: orchestrated by main.yml. workflow_dispatch is kept so this
+# suite can still be run on its own from the Actions UI.
 
 on:
-  push:
-    branches:
-      - "*"
-    tags:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
-  pull_request:
-    branches:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ on:
       - '!*.md'
   workflow_dispatch:
 
+# 最小権限: 全ジョブ checkout / build / test のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   # Cheap fail-fast gate on a single runner: build the action and run the unit
   # tests before fanning out to the ~60 OS / container matrix jobs below. A
@@ -33,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+name: "CI"
+
+# Orchestrator workflow. push / pull_request triggers live here only; the
+# individual test suites are reusable workflows (`on: workflow_call`) invoked
+# below, so a single CI run drives all of them instead of each firing its own
+# push / PR event. (Each suite also keeps `workflow_dispatch` for manual,
+# individual re-runs from the Actions UI.)
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - '**'
+      - '!*.md'
+  workflow_dispatch:
+
+jobs:
+  # Cheap fail-fast gate on a single runner: build the action and run the unit
+  # tests before fanning out to the ~60 OS / container matrix jobs below. A
+  # broken build or failing jest run is caught here in ~1-2 min instead of
+  # spinning up the expensive macOS / Windows / container suites.
+  # (format-check is intentionally NOT run here -- it is non-gating; keeping it
+  # out preserves the existing CI semantics.)
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          # fork PR ではキャッシュ汚染 (信頼境界の共有) を避けるため pnpm
+          # キャッシュを無効化する。自リポジトリの push / PR では有効のまま。
+          cache: ${{ github.event.pull_request.head.repo.fork != true && 'pnpm' || '' }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm package
+      - run: pnpm test
+
+  # Heavy E2E / install suites. They only start once the cheap gate above is
+  # green, but run in parallel with each other.
+  nix-test:
+    needs: build-and-test
+    uses: ./.github/workflows/test.yml
+  windows-test:
+    needs: build-and-test
+    uses: ./.github/workflows/windows.yml
+  container-test:
+    needs: build-and-test
+    uses: ./.github/workflows/container-test.yml
+  legacy-test:
+    needs: build-and-test
+    uses: ./.github/workflows/legacy-test.yml
+  version-resolution-test:
+    needs: build-and-test
+    uses: ./.github/workflows/version-resolution-test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,9 @@
 name: "Test chromedriver on *NIX"
+# Reusable workflow: orchestrated by main.yml. workflow_dispatch is kept so this
+# suite can still be run on its own from the Actions UI.
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
-  pull_request:
-    branches:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -28,13 +18,6 @@ jobs:
           - macos-latest
           - macos-15
           - macos-14
-        branch:
-          # TEMPORARY parity gate (issue #159): run @master (current shell) and
-          # 'now' (new native TypeScript) side-by-side to prove behavioral
-          # parity across the OS matrix. Re-comment 'master' once the TS rewrite
-          # is confirmed stable and released.
-          - 'master'
-          - 'now'
         chrome_version:
           - 'current'
           # FIXME https://github.com/nanasess/setup-chromedriver/issues/229
@@ -73,12 +56,6 @@ jobs:
         CHROME_VERSION=$("$CHROMEAPP" --version | cut -f 3 -d ' ')
         echo "CHROMEDRIVER_VERSION=$CHROME_VERSION" >> $GITHUB_ENV
     - uses: ./
-      if: matrix.branch == 'now'
-      with:
-        chromedriver-version: ${{ env.CHROMEDRIVER_VERSION }}
-        chromeapp: ${{ env.CHROMEAPP }}
-    - uses: nanasess/setup-chromedriver@master
-      if: matrix.branch == 'master'
       with:
         chromedriver-version: ${{ env.CHROMEDRIVER_VERSION }}
         chromeapp: ${{ env.CHROMEAPP }}
@@ -103,13 +80,6 @@ jobs:
           - macos-latest
           - macos-15
           - macos-14
-        branch:
-          # TEMPORARY parity gate (issue #159): run @master (current shell) and
-          # 'now' (new native TypeScript) side-by-side to prove behavioral
-          # parity across the OS matrix. Re-comment 'master' once the TS rewrite
-          # is confirmed stable and released.
-          - 'master'
-          - 'now'
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - if: startsWith(matrix.os, 'ubuntu')
@@ -134,9 +104,6 @@ jobs:
     #     # node_modules/.bin/ncc build $GITHUB_WORKSPACE/__tests__/chromedriver.js -o $GITHUB_WORKSPACE/__tests__
         # rm -rf node_modules
     - uses: ./
-      if: matrix.branch == 'now'
-    - uses: nanasess/setup-chromedriver@master
-      if: matrix.branch == 'master'
     - name: setup
       run: |
         "$CHROMEAPP" --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# 最小権限: checkout / build / test のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -24,6 +28,8 @@ jobs:
           # - '114.0.5735.90'
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - if: startsWith(matrix.os, 'ubuntu')
       run: echo 'CHROMEAPP=google-chrome' >> $GITHUB_ENV
     - if: startsWith(matrix.os, 'macos')
@@ -82,6 +88,8 @@ jobs:
           - macos-14
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - if: startsWith(matrix.os, 'ubuntu')
       run: echo 'CHROMEAPP=google-chrome' >> $GITHUB_ENV
     - if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/version-resolution-test.yml
+++ b/.github/workflows/version-resolution-test.yml
@@ -29,6 +29,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# 最小権限: checkout / アクション実行のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   resolve:
     name: "${{ matrix.os }} / ${{ matrix.case.version }}"
@@ -61,6 +65,8 @@ jobs:
       EXPECT: ${{ matrix.case.expect }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # Windows: the action reads the installed Chrome's FileVersion up front,
       # so chromeapp must point at the pre-installed Chrome. (Left empty on

--- a/.github/workflows/version-resolution-test.yml
+++ b/.github/workflows/version-resolution-test.yml
@@ -20,23 +20,13 @@ name: "Test ChromeDriver version resolution"
 # assert that `chromedriver --version` reports the expected version.
 #
 # `uses: ./` exercises the action code of the current commit (the native
-# TypeScript implementation on this branch / on master after #446 merges).
+# TypeScript implementation).
+#
+# Reusable workflow: orchestrated by main.yml. workflow_dispatch is kept so this
+# suite can still be run on its own from the Actions UI.
 
 on:
-  push:
-    branches:
-      - "*"
-    tags:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
-  pull_request:
-    branches:
-      - "*"
-    paths:
-      - "**"
-      - "!*.md"
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,19 +1,9 @@
 name: "Test chromedriver on Windows"
+# Reusable workflow: orchestrated by main.yml. workflow_dispatch is kept so this
+# suite can still be run on its own from the Actions UI.
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
-  pull_request:
-    branches:
-      - '*'
-    paths:
-      - '**'
-      - '!*.md'
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -22,13 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, windows-2025, windows-2022 ]
-        branch:
-          # TEMPORARY parity gate (issue #159): run @master (current shell) and
-          # 'now' (new native TypeScript) side-by-side to prove behavioral
-          # parity across the OS matrix. Re-comment 'master' once the TS rewrite
-          # is confirmed stable and released.
-          - 'master'
-          - 'now'
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - shell: pwsh
@@ -66,12 +49,6 @@ jobs:
             echo "CHROMEDRIVER_VERSION=$chrome_fullversion" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
         }
     - uses: ./
-      if: matrix.branch == 'now'
-      with:
-        chromedriver-version: ${{ env.CHROMEDRIVER_VERSION }}
-        chromeapp: ${{ env.CHROMEAPP }}
-    - uses: nanasess/setup-chromedriver@master
-      if: matrix.branch == 'master'
       with:
         chromedriver-version: ${{ env.CHROMEDRIVER_VERSION }}
         chromeapp: ${{ env.CHROMEAPP }}
@@ -86,13 +63,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, windows-2025, windows-2022 ]
-        branch:
-          # TEMPORARY parity gate (issue #159): run @master (current shell) and
-          # 'now' (new native TypeScript) side-by-side to prove behavioral
-          # parity across the OS matrix. Re-comment 'master' once the TS rewrite
-          # is confirmed stable and released.
-          - 'master'
-          - 'now'
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - shell: pwsh
@@ -116,9 +86,6 @@ jobs:
     #     # rm -rf node_modules
     #   shell: bash
     - uses: ./
-      if: matrix.branch == 'now'
-    - uses: nanasess/setup-chromedriver@master
-      if: matrix.branch == 'master'
     - name: setup
       run: |
         chromedriver --url-base=/wd/hub &

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# 最小権限: checkout / build / test のみで書き込み不要。
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -14,6 +18,8 @@ jobs:
         os: [ windows-latest, windows-2025, windows-2022 ]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - shell: pwsh
       run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -65,6 +71,8 @@ jobs:
         os: [ windows-latest, windows-2025, windows-2022 ]
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - shell: pwsh
       run: echo "CHROMEAPP=C:\Program Files\Google\Chrome\Application\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8


### PR DESCRIPTION
## Summary

- Remove the temporary parity gate from issue #159 (the `branch` matrix that ran `@master` side-by-side with the current commit). The TypeScript rewrite has shipped as v3 and `master` is now frozen with a deprecation warning (#463), so the gate has served its purpose.
- Convert each test suite into a reusable workflow (`on: workflow_call`) and add a new `main.yml` that drives them all from a single push / pull_request run, EC-CUBE style.
- Add a cheap `build-and-test` pre-gate so a broken build or failing unit test fails fast, before the expensive OS / container matrix (especially the macOS-billed jobs) ever spins up.

## Changes

- **`test.yml` / `windows.yml`**: drop the `branch` (`master` / `now`) matrix axis and make `uses: ./` unconditional. Remove the `nanasess/setup-chromedriver@master` steps.
- **`main.yml` (new)**: owns the push / pull_request / workflow_dispatch triggers.
  - Adds `build-and-test` (single ubuntu job: install → build → package → jest) as a fail-fast pre-gate.
  - The five suites (nix / windows / container / legacy / version-resolution) `needs: build-and-test`, and run in parallel with each other.
  - No aggregate `success` job, since no required status check is configured in branch protection.
- **The five child workflows**: change `on:` to `workflow_call` + `workflow_dispatch` (the latter kept for manual, individual re-runs). The push / pull_request triggers are consolidated into `main.yml` to avoid double runs.
- **Comment cleanup**: fix the stale "on master" / "after #446 merges" notes in `legacy-test.yml` / `version-resolution-test.yml` to reflect the native TypeScript implementation.

### Notes
- `format-check` is intentionally left out of the pre-gate, preserving its existing non-gating behavior.
- ⚠️ Job names become nested (`CI / nix-test / test`, etc.), but there is no impact since no required status check is configured in branch protection.

## Test plan

- [x] All eight workflows parse as valid YAML (`yaml.safe_load`)
- [x] No leftover `matrix.branch` / `@master` references (verified with `rg`)
- [ ] CI on this PR exercises the `build-and-test` → five-suite `needs` chain as intended
- [ ] Reusable workflow calls resolve on the runner (actionlint not installed locally; verified by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)