### PR TITLE
fix(test): Windows E2E の flaky 対策 (chrome not reachable)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,6 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # disable headless mode
         fi
-        chromedriver --url-base=/wd/hub &
         node_modules/.bin/ts-node $GITHUB_WORKSPACE/__tests__/chromedriver.ts
 
   test_default_version:
@@ -119,5 +118,4 @@ jobs:
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # disable headless mode
         fi
-        chromedriver --url-base=/wd/hub &
         node_modules/.bin/ts-node $GITHUB_WORKSPACE/__tests__/chromedriver.ts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,6 @@ jobs:
         chromeapp: ${{ env.CHROMEAPP }}
     - name: setup
       run: |
-        chromedriver --url-base=/wd/hub &
         node_modules\.bin\ts-node "$Env:GITHUB_WORKSPACE\__tests__\chromedriver.ts"
 
   test_default_version:
@@ -96,5 +95,4 @@ jobs:
     - uses: ./
     - name: setup
       run: |
-        chromedriver --url-base=/wd/hub &
         node_modules\.bin\ts-node "$Env:GITHUB_WORKSPACE\__tests__\chromedriver.ts"

--- a/__tests__/chromedriver.ts
+++ b/__tests__/chromedriver.ts
@@ -1,4 +1,4 @@
-import { Builder, Capabilities, until } from "selenium-webdriver";
+import { Builder, until } from "selenium-webdriver";
 // ESM (the project is "type":"module") requires an explicit extension for this
 // CJS subpath; without it Node throws ERR_MODULE_NOT_FOUND under ts-node.
 import * as chrome from "selenium-webdriver/chrome.js";
@@ -14,7 +14,9 @@ import * as chrome from "selenium-webdriver/chrome.js";
     "--disable-gpu",
     "--disable-web-security",
     "--disable-features=VizDisplayCompositor",
-    "--remote-debugging-port=9222",
+    // NOTE: do NOT pin --remote-debugging-port. Recent ChromeDriver negotiates
+    // the DevTools port itself; a fixed port intermittently triggers
+    // "chrome not reachable" on the Windows CI runners (port reuse / races).
     "--disable-background-timer-throttling",
     "--disable-backgrounding-occluded-windows",
     "--disable-renderer-backgrounding",
@@ -34,10 +36,27 @@ import * as chrome from "selenium-webdriver/chrome.js";
     options.addArguments(`--user-data-dir=${userDataDir}`);
   }
 
-  const driver = new Builder()
-    .forBrowser("chrome")
-    .setChromeOptions(options)
-    .build();
+  // Session creation ("chrome not reachable" / "session not created") is the
+  // dominant flaky failure on the Windows CI runners. Retry a few times before
+  // giving up so a single transient hiccup does not fail the whole job.
+  const buildWithRetry = async (attempts = 3, delayMs = 2000) => {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await new Builder()
+          .forBrowser("chrome")
+          .setChromeOptions(options)
+          .build();
+      } catch (err) {
+        if (attempt >= attempts) throw err;
+        console.log(
+          `session creation failed (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms: ${err}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  };
+
+  const driver = await buildWithRetry();
   try {
     await driver.get("https://google.com");
     await driver.wait(until.titleContains("Google"), timeout);


### PR DESCRIPTION
## 背景

PR #475 (dependabot) の CI で Windows ジョブが落ちたが、これはコード変更とは無関係な flaky:

```
SessionNotCreatedError: session not created
from chrome not reachable
```

参考 run: https://github.com/nanasess/setup-chromedriver/actions/runs/27311995317/job/80684129810

ユニットテスト (`pnpm test`) は全 PASS、Chrome/ChromeDriver のバージョンも一致 (共に `149.0.7827.54`)。Windows ランナー上のセッション生成が散発的に失敗していた。

## 変更内容

| 対策 | 内容 |
|---|---|
| **A. リトライ** | `__tests__/chromedriver.ts` の `Builder.build()` を最大3回 (間隔2s) リトライ。単発の起動失敗でジョブ全体を落とさない |
| **B. 固定ポート削除** | ハードコードしていた `--remote-debugging-port=9222` を削除。近年の ChromeDriver は DevTools ポートを自身でネゴシエートするため、固定ポートはポート競合/再利用で `chrome not reachable` を誘発し得る |
| **C. 不要プロセス削除** | 事前起動していた `chromedriver --url-base=/wd/hub &` を `test.yml` / `windows.yml` から削除。selenium の `Builder` は自前で ChromeDriver を起動しており **このプロセスには接続していない** (未使用)。ポート競合の火種でしかなかった |

ついでに未使用の `Capabilities` import も削除。

## 検証

- [x] `pnpm test` — 98 passed / 4 skipped
- [x] `prettier --check` — OK
- [ ] CI 上の Windows E2E (本 PR の Actions で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Windows環境でのテスト実行の安定性を向上させました。セッション作成失敗に対するリトライ機能を実装しました。

* **Chores**
  * CI/CDパイプラインを簡略化し、テストインフラストラクチャの効率性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->