### PR TITLE
fix: Claude Code Review not posting comments (missing --comment flag)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,9 @@ jobs:
           # be pinned to a commit here and tracks the default branch HEAD.
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          allowed_tools: |
+            mcp__github_inline_comment__create_inline_comment
+            Bash(gh pr comment:*)
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

- Add `--comment` flag to `prompt` in `claude-code-review.yml` so the review phase actually posts comments to the PR
- Add `mcp__github_inline_comment__create_inline_comment` to `allowed_tools` to enable the inline comment posting path via MCP server
- Preserve `Bash(gh pr comment:*)` as a fallback

## Root Cause

The `prompt` was invoking `/code-review:code-review <repo>/pull/<num>` **without `--comment`**. Per the plugin's [code-review.md](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) step 7:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

The review ran and completed, but the posting phase was never reached.

## Test plan

- [ ] Open a PR and confirm Claude posts inline review comments
- [ ] Verify the workflow completes without permission errors for `mcp__github_inline_comment__create_inline_comment`

Closes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions の自動コードレビューワークフロー設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->