### PR TITLE
fix: bump js-yaml to security-patched 4.2.0 via pnpm override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   qs: '>=6.15.2'
+  js-yaml@^3: ^4.2.0
 
 importers:
 
@@ -634,8 +635,8 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   babel-jest@30.4.1:
     resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
@@ -837,11 +838,6 @@ packages:
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -1141,8 +1137,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1423,9 +1419,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -1904,7 +1897,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -2312,9 +2305,7 @@ snapshots:
 
   arg@4.1.3: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
+  argparse@2.0.1: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -2506,8 +2497,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
-
-  esprima@4.0.1: {}
 
   execa@5.1.1:
     dependencies:
@@ -3005,10 +2994,9 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@4.2.0:
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
 
   jsesc@3.1.0: {}
 
@@ -3252,8 +3240,6 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
-
-  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,3 +39,11 @@ allowBuilds:
 # を塞ぐため override で 6.15.2 以上へ引き上げる。patch 上げで API 互換。
 overrides:
   qs: '>=6.15.2'
+  # js-yaml: jest のカバレッジ機構 (@jest/transform → babel-plugin-istanbul →
+  # @istanbuljs/load-nyc-config) が js-yaml@^3.13.1 をピン留めしており、修正版
+  # 4.2.0 を使う上流が存在しない。GHSA (js-yaml <=4.1.1 / 修正 >=4.2.0) を塞ぐ
+  # ため override で 4 系へ引き上げる。当プロジェクトは jest のカバレッジを
+  # 一切使わない (jest.config.mjs に collectCoverage なし / transform は ts-jest
+  # のみ) ため load-nyc-config は実行されず、js-yaml 3→4 の API 差異 (safeLoad
+  # 削除等) の影響を受けない。3 系のみを対象にするためセレクタを付ける。
+  js-yaml@^3: '^4.2.0'


### PR DESCRIPTION
## Summary

- Fixes the Dependabot security update for `js-yaml` that kept failing with `security_update_not_possible`
- `js-yaml` is a transitive dev-only dependency pulled in by Jest's coverage machinery, and no upstream uses the patched 4.2.0, so Dependabot alone cannot bump it
- Force-raises the 3.x line to 4.2.0 via `overrides` in `pnpm-workspace.yaml`

## Background

`js-yaml` is not a direct dependency; it enters through this dev-only chain:

```
js-yaml@3.14.2
└─ @istanbuljs/load-nyc-config@1.1.0   ← pins js-yaml@^3.13.1
   └─ babel-plugin-istanbul@7.0.1
      └─ @jest/transform (jest@30 coverage machinery)
```

Because `@istanbuljs/load-nyc-config` requires `js-yaml@^3.13.1`, the tree cannot resolve to 4.x, so Dependabot reported "latest resolvable version 3.14.2 / lowest non-vulnerable 4.2.0" and gave up (GHSA: js-yaml `<=4.1.1` vulnerable / fixed in `>=4.2.0`).

This project does not use Jest coverage at all (`jest.config.mjs` has no `collectCoverage`, and the only transform is ts-jest), so `load-nyc-config` is never executed and the js-yaml 3→4 API changes (e.g. removal of `safeLoad`) cannot affect us. Raising it to 4.x via override is therefore safe.

## Changes

- `pnpm-workspace.yaml`: add `js-yaml@^3: '^4.2.0'` to `overrides` (same style as the existing `qs` override, with the rationale documented in a comment)
- `pnpm-lock.yaml`: regenerated, js-yaml 3.14.2 → 4.2.0 (the `argparse`/`esprima`/`sprintf-js` churn is the legitimate side effect of js-yaml 4 depending only on argparse 2)

`src/**` is unchanged and js-yaml is not bundled into `dist/index.js`, so no `pnpm build` / `pnpm package` regeneration is needed.

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm install --frozen-lockfile` (CI equivalent) succeeds — also clears the 1440-minute minimumReleaseAge
- [x] `pnpm test` — 99 passed / 7 suites, zero failures
- [x] `pnpm why js-yaml` — `Found 1 version of js-yaml` = a single 4.2.0
- [x] CI green

Closes the Dependabot security alert (js-yaml, GHSA `<=4.1.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)